### PR TITLE
Fix FastEmit kernel

### DIFF
--- a/include/detail/gpu_rnnt.h
+++ b/include/detail/gpu_rnnt.h
@@ -196,9 +196,16 @@ GpuRNNT<ProbT>::compute_cost_and_score(const ProbT* const acts,
         start = std::chrono::high_resolution_clock::now();
 #endif
         // TODO optimize gradient kernel
-        compute_grad_kernel<128, ProbT><<<minibatch_ * maxT_ * maxU_, 128, 0, stream_>>>(grads, 
-            acts, denom, alphas, betas, llForward, input_lengths, label_lengths, labels, 
-            minibatch_, maxT_, maxU_, alphabet_size_, blank_, fastemit_lambda_);
+
+        if (fastemit_lambda_ > 0.0f) {
+            compute_fastemit_grad_kernel<128, ProbT><<<minibatch_ * maxT_ * maxU_, 128, 0, stream_>>>(grads, 
+                acts, denom, alphas, betas, llForward, input_lengths, label_lengths, labels, 
+                minibatch_, maxT_, maxU_, alphabet_size_, blank_, fastemit_lambda_);
+        } else {
+            compute_grad_kernel<128, ProbT><<<minibatch_ * maxT_ * maxU_, 128, 0, stream_>>>(grads, 
+                acts, denom, alphas, betas, llForward, input_lengths, label_lengths, labels, 
+                minibatch_, maxT_, maxU_, alphabet_size_, blank_);
+        }
 #if defined(DEBUG_TIME)
         cudaStreamSynchronize(stream_);
         end = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
This PR fixes the GPU implementation of the FastEmit gradient computation.

Specifically, the FastEmit gradient formula in the CUDA kernel has been modified based on the logit-based formula (See [documents](https://github.com/HawkAaron/warp-transducer/blob/master/docs/rnnt_notes.pdf)).
Also, when FastEmit is not enabled, the conventional gradient calculation kernel is used because there is a small difference in execution efficiency.

We have confirmed on a small test case (B=1, T=7, U=5, V=5) that the original FastEmit implementation has a gradient error of 0.1% compared to the CPU version, while our implementation reduces the gradient error to about 0.01-0.001%.

@yusshino helped to create this PR.